### PR TITLE
New URL for UF

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is an Ansible project that installs or upgrades Splunk to a specific versio
 
 2. git clone this project
 
-		- git clone https://github.com/johnmcgovern/ansible-splunk-base.git
+		- git clone https://github.com/h4llm3n/ansible-splunk-base.git
 	
 3. Navigate to project base directory
 
@@ -125,8 +125,3 @@ This role has been tested on:
 ### Warranty
 
 This project is provided WITHOUT any form of warranty and should be tested thoroughly before using it in your environment. Development is best-effort only. This project is provided as-is with no guarantee as to fitness for a specific purpose. Please use it at your own risk.
-
-
-### Contact
-
-- john@johnmcgovern.com or https://www.johnmcgovern.com

--- a/roles/uf-install/tasks/main.yml
+++ b/roles/uf-install/tasks/main.yml
@@ -35,7 +35,7 @@
 
 - name: -TGZ- Download (wget) {{ splunk_uf_tgz }}
   get_url:
-    url: "https://d7wz6hmoaavd0.cloudfront.net/products/splunk/releases/{{ splunk_uf_version }}/linux/{{ splunk_uf_tgz }}"    
+    url: "https://d7wz6hmoaavd0.cloudfront.net/products/universalforwarder/releases/{{ splunk_uf_version }}/linux/{{ splunk_uf_tgz }}"    
     checksum: "md5:{{ splunk_uf_tgz_checksum }}"
     dest: /home/{{ os_user }}
     mode: 0640  

--- a/roles/uf-upgrade/tasks/main.yml
+++ b/roles/uf-upgrade/tasks/main.yml
@@ -24,7 +24,7 @@
 
 - name: -TGZ- Download (wget) {{ splunk_uf_tgz }}
   get_url:
-    url: "https://d7wz6hmoaavd0.cloudfront.net/products/splunk/releases/{{ splunk_uf_version }}/linux/{{ splunk_uf_tgz }}"    
+    url: "https://d7wz6hmoaavd0.cloudfront.net/products/universalforwarder/releases/{{ splunk_uf_version }}/linux/{{ splunk_uf_tgz }}"    
     checksum: "md5:{{ splunk_uf_tgz_checksum }}"
     dest: /home/{{ os_user }}
     mode: 0640  


### PR DESCRIPTION
Path changed from d7wz6hmoaavd0.cloudfront.net/products/splunk/releases/ to d7wz6hmoaavd0.cloudfront.net/products/universalforwarder/releases/